### PR TITLE
Refactor built-in storages to be more tightly coupled with vector abstraction

### DIFF
--- a/particular/CHANGELOG.md
+++ b/particular/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ParticleStorage` trait blanket implemented for storages of `ParticlePointMass`.
 - `TreeAffected` storage.
+- `MassiveAffectedInternal` and `MassiveAffectedArray`, newtypes around `MassiveAffected`.
+- `BarnesHutTree` alias.
 - `Zero` trait for types that have an identity value.
 
 ### Changed
@@ -18,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BarnesHut` compute methods use `TreeAffected` instead of `MassiveAffected`. This gives potential access to the tree built to compute the accelerations.
 - `ComputeMethod::compute` takes the storage by reference.
 - Use the `Zero` trait in place of the `Default` trait when applicable.
+- `IntoVectorArray` is now `ConvertInternal` and `IntoVectorElement` is now `ConvertSIMD`.
+- Renamed `ParticleSet` to `ParticleSetInternal`.
+- `MassiveAffected` no longer implements `Storage`. `MassiveAffectedInternal` and `MassiveAffectedArray` newtypes are used instead.
+- `BarnesHutTree` trait renamed to `BarnesHutAcceleration`.
+
+### Removed
+
+- Trait methods of `IntoVectorElement`.
+- `Element` trait.
+- `PointMass::into_element` method.
 
 ## [0.6.1] - 2023-19-07
 

--- a/particular/src/algorithms/gpu.rs
+++ b/particular/src/algorithms/gpu.rs
@@ -1,10 +1,10 @@
 use crate::{
     algorithms::{
-        internal,
+        vector,
         wgpu_data::{setup_wgpu, WgpuData},
-        MassiveAffected, PointMass,
+        MassiveAffectedArray, PointMass,
     },
-    compute_method::{ComputeMethod, Storage},
+    compute_method::ComputeMethod,
 };
 
 const PARTICLE_SIZE: u64 = std::mem::size_of::<PointMass<[f32; 3], f32>>() as u64;
@@ -20,14 +20,15 @@ pub struct BruteForce {
     queue: wgpu::Queue,
 }
 
-impl<V> ComputeMethod<MassiveAffected<[f32; 3], f32>, V> for &mut BruteForce
+impl<V> ComputeMethod<MassiveAffectedArray<3, f32, V>, V> for &mut BruteForce
 where
-    V: From<[f32; 3]>,
+    V: vector::ConvertArray<3, f32, Array = [f32; 3]>,
 {
     type Output = Vec<V>;
 
     #[inline]
-    fn compute(self, storage: &MassiveAffected<[f32; 3], f32>) -> Self::Output {
+    fn compute(self, storage: &MassiveAffectedArray<3, f32, V>) -> Self::Output {
+        let storage = &storage.0;
         let particles_len = storage.affected.len() as u64;
         let massive_len = storage.massive.len() as u64;
 
@@ -91,17 +92,6 @@ impl BruteForce {
 impl Default for BruteForce {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl<S, const DIM: usize, V> Storage<PointMass<V, S>> for MassiveAffected<[S; DIM], S>
-where
-    S: internal::Scalar,
-    V: Into<[S; DIM]>,
-{
-    #[inline]
-    fn store<I: Iterator<Item = PointMass<V, S>>>(input: I) -> Self {
-        Self::from_affected(input.map(PointMass::into).collect())
     }
 }
 

--- a/particular/src/algorithms/gpu.rs
+++ b/particular/src/algorithms/gpu.rs
@@ -95,8 +95,8 @@ impl Default for BruteForce {
     }
 }
 
-unsafe impl<S, const DIM: usize> bytemuck::Zeroable for super::PointMass<[S; DIM], S> {}
-unsafe impl<S: bytemuck::Pod, const DIM: usize> bytemuck::Pod for super::PointMass<[S; DIM], S> {}
+unsafe impl<S, const D: usize> bytemuck::Zeroable for super::PointMass<[S; D], S> {}
+unsafe impl<S: bytemuck::Pod, const D: usize> bytemuck::Pod for super::PointMass<[S; D], S> {}
 
 #[cfg(test)]
 mod tests {

--- a/particular/src/algorithms/storage.rs
+++ b/particular/src/algorithms/storage.rs
@@ -1,7 +1,7 @@
 use crate::{
     algorithms::{
         internal, simd,
-        tree::{BoundingBox, NodeID, SizedOrthant, SubDivide, Tree},
+        tree::{BarnesHutTree, BoundingBox, NodeID, SubDivide},
         vector, Zero,
     },
     compute_method::Storage,
@@ -54,30 +54,17 @@ impl<V, S> PointMass<V, S> {
     where
         V: Into<T>,
     {
-        PointMass {
-            position: self.position.into(),
-            mass: self.mass,
-        }
+        PointMass::new(self.position.into(), self.mass)
     }
 
     /// Converts from a [`PointMass<V, S>`] to a [`PointMass<V::Internal, S>`]
     /// provided `V` implements [`internal::IntoVectorArray`].
     #[inline]
-    pub fn into_internal<const DIM: usize>(self) -> PointMass<V::Vector, S>
+    pub fn into_internal<const D: usize>(self) -> PointMass<V::Vector, S>
     where
-        V: internal::ConvertInternalVector<DIM, S>,
+        V: internal::ConvertInternal<D, S>,
     {
         PointMass::new(self.position.into_internal(), self.mass)
-    }
-
-    /// Converts from a [`PointMass<V, S>`] to a [`PointMass<E, S>`]
-    /// provided `V` implements [`simd::IntoVectorElement<E>`].
-    #[inline]
-    pub fn into_element<E>(self) -> PointMass<E, S>
-    where
-        V: simd::IntoVectorElement<E>,
-    {
-        PointMass::new(self.position.into_element(), self.mass)
     }
 }
 
@@ -116,10 +103,10 @@ impl<V, S> PointMass<V, S> {
     /// Computes the gravitational acceleration exerted on this particle by the provided particle
     /// provided `S` and `V` implement [`simd::Scalar`] and [`simd::Vector`] respectively.
     #[inline]
-    pub fn acceleration_simd<const LANES: usize>(&self, particle: &Self) -> V
+    pub fn acceleration_simd<const L: usize>(&self, particle: &Self) -> V
     where
-        S: simd::Scalar<LANES>,
-        V: simd::Vector<LANES, Scalar = S>,
+        S: simd::Scalar<L>,
+        V: simd::Vector<L, Scalar = S>,
     {
         let dir = particle.position - self.position;
         let mag_2 = dir.length_squared();
@@ -131,10 +118,10 @@ impl<V, S> PointMass<V, S> {
     /// Computes the total gravitational acceleration exerted on this particle by the provided slice of particles
     /// provided `S` and `V` implement [`simd::Scalar`] and [`simd::Vector`] respectively.
     #[inline]
-    pub fn total_acceleration_simd<const LANES: usize>(&self, particles: &[Self]) -> V
+    pub fn total_acceleration_simd<const L: usize>(&self, particles: &[Self]) -> V
     where
-        S: simd::Scalar<LANES>,
-        V: simd::Vector<LANES, Scalar = S>,
+        S: simd::Scalar<L>,
+        V: simd::Vector<L, Scalar = S>,
     {
         particles.iter().fold(V::ZERO, |acceleration, p2| {
             acceleration + self.acceleration_simd(p2)
@@ -144,9 +131,9 @@ impl<V, S> PointMass<V, S> {
 
 /// Simple storage for particles using a vector.
 #[derive(Debug, Default, Clone)]
-pub struct ParticleSetInternal<const DIM: usize, S, V>(pub Vec<PointMass<V::Vector, S>>)
+pub struct ParticleSetInternal<const D: usize, S, V>(pub Vec<PointMass<V::Vector, S>>)
 where
-    V: internal::ConvertInternalVector<DIM, S>;
+    V: internal::ConvertInternal<D, S>;
 
 /// Storage for particles with massive and affected particles in two separate vectors.
 #[derive(Debug, Default, Clone)]
@@ -180,121 +167,43 @@ impl<T, S> MassiveAffected<T, S> {
 
 /// Storage for particles with massive and affected particles in two separate vectors using arrays for the position.
 #[derive(Debug, Default, Clone)]
-pub struct MassiveAffectedArray<const DIM: usize, S, V>(pub MassiveAffected<V::Array, S>)
+pub struct MassiveAffectedArray<const D: usize, S, V>(pub MassiveAffected<V::Array, S>)
 where
-    V: vector::ConvertArray<DIM, S>;
+    V: vector::ConvertArray<D, S>;
 
 /// Storage for particles with massive and affected particles in two separate vectors using [`internal::Vector`]s for the position.
 #[derive(Debug, Default, Clone)]
-pub struct MassiveAffectedInternal<const DIM: usize, S, V>(pub MassiveAffected<V::Vector, S>)
+pub struct MassiveAffectedInternal<const D: usize, S, V>(pub MassiveAffected<V::Vector, S>)
 where
-    V: internal::ConvertInternalVector<DIM, S>;
+    V: internal::ConvertInternal<D, S>;
+
+/// Storage for particles with massive and affected particles in two separate vectors.
+///
+/// Particles are stored using [`simd::Vector`] and [`simd::Scalar`] for the massive ones and arrays for the massless ones.
+#[derive(Clone)]
+pub struct MassiveAffectedSIMD<const L: usize, const D: usize, S, V>(
+    pub MassiveAffected<V::Array, S, V::Vector, V::Scalar>,
+)
+where
+    V: simd::ConvertSIMD<L, D, S>;
 
 /// Storage with a [`Tree`] built from the massive particles and affected particles in another vector.
 #[derive(Debug, Default, Clone)]
-#[allow(clippy::type_complexity)]
-pub struct TreeAffectedInternal<const N: usize, const DIM: usize, S, V>
+pub struct TreeAffectedInternal<const N: usize, const D: usize, S, V>
 where
-    V: internal::ConvertInternalVector<DIM, S>,
+    V: internal::ConvertInternal<D, S>,
 {
     /// [`Tree`] built from the massive particles.
-    pub tree: Tree<SizedOrthant<N, BoundingBox<[S; DIM]>>, PointMass<V::Vector, S>>,
+    pub tree: BarnesHutTree<N, D, V::Vector, S>,
     /// Root of the `tree`.
     pub root: Option<NodeID>,
     /// Particles for which the acceleration is computed.
     pub affected: Vec<PointMass<V::Vector, S>>,
 }
 
-impl<const N: usize, const DIM: usize, S, V, T> TreeAffectedInternal<N, DIM, S, V>
+impl<const D: usize, S, V> Storage<PointMass<V, S>> for ParticleSetInternal<D, S, V>
 where
-    V: internal::ConvertInternalVector<DIM, S, Vector = T>,
-{
-    /// Creates a new [`MassiveAffected`] from the given vector of particles.
-    ///
-    /// This method populates the `affected` vector with the given particles and copies the ones with mass to the `massive` vector.
-    pub fn from_affected(affected: Vec<PointMass<T, S>>) -> Self
-    where
-        S: internal::Scalar,
-        T: internal::Vector<Scalar = S> + Into<[S; DIM]>,
-        BoundingBox<[S; DIM]>: SubDivide<Divison = [BoundingBox<[S; DIM]>; N]>,
-    {
-        let MassiveAffected { massive, affected } = MassiveAffected::from_affected(affected);
-
-        let mut tree = Tree::new();
-        let bbox = BoundingBox::square_with(massive.iter().map(|p| p.position.into()));
-        let root = tree.build_node(&massive, bbox);
-
-        Self {
-            tree,
-            root,
-            affected,
-        }
-    }
-}
-
-/// Storage for particles with massive and affected particles in two separate vectors using [`simd::Vector`]s for the position and [`simd::Scalar`]s for the mass.
-#[derive(Debug, Default, Clone)]
-pub struct MassiveAffectedSIMD<const LANES: usize, T, S>
-where
-    T: simd::SIMD<LANES>,
-    S: simd::SIMD<LANES>,
-{
-    /// Particles used to compute the acceleration of the `affected` particles.
-    pub massive: Vec<PointMass<T, S>>,
-    /// Particles for which the acceleration is computed.
-    ///
-    /// This vector and the `massive` vector can share particles.
-    pub affected: Vec<PointMass<T::Element, S::Element>>,
-}
-
-impl<const LANES: usize, T, S> MassiveAffectedSIMD<LANES, T, S>
-where
-    T: simd::SIMD<LANES>,
-    S: simd::SIMD<LANES>,
-{
-    /// Creates a new [`MassiveAffectedSIMD`] from the given vector of particles of [`simd::SIMD::Element`].
-    ///
-    /// This method populates the `affected` vector with the given particles and copies the ones with mass to the `massive` vector.
-    pub fn from_affected(affected: Vec<PointMass<T::Element, S::Element>>) -> Self {
-        let massive = affected
-            .iter()
-            .filter(|p| p.is_massive())
-            .copied()
-            .collect();
-
-        Self::particles_to_simd(massive, affected)
-    }
-
-    /// Creates a new [`MassiveAffectedSIMD`] instance with the given vectors of particles of [`simd::SIMD::Element`].
-    ///
-    /// The given massive vector will be iterated over `LANES` elements at a time and mapped to particles of [`simd::SIMD`] values.
-    #[inline]
-    pub fn particles_to_simd(
-        massive: Vec<PointMass<T::Element, S::Element>>,
-        affected: Vec<PointMass<T::Element, S::Element>>,
-    ) -> Self {
-        let massive = massive
-            .chunks(LANES)
-            .map(|slice| {
-                let mut body_8 = [PointMass::ZERO; LANES];
-                body_8[..slice.len()].copy_from_slice(slice);
-
-                PointMass::new(
-                    T::from_lanes(body_8.map(|p| p.position)),
-                    S::from_lanes(body_8.map(|p| p.mass)),
-                )
-            })
-            .collect();
-
-        Self { massive, affected }
-    }
-}
-
-impl<const DIM: usize, S, V, T> Storage<PointMass<V, S>> for ParticleSetInternal<DIM, S, V>
-where
-    S: internal::Scalar,
-    T: internal::Vector<Scalar = S>,
-    V: internal::ConvertInternalVector<DIM, S, Vector = T>,
+    V: internal::ConvertInternal<D, S>,
 {
     #[inline]
     fn store<I>(input: I) -> Self
@@ -305,11 +214,10 @@ where
     }
 }
 
-impl<const DIM: usize, S, V, A> Storage<PointMass<V, S>> for MassiveAffectedArray<DIM, S, V>
+impl<const D: usize, S, V> Storage<PointMass<V, S>> for MassiveAffectedArray<D, S, V>
 where
-    S: internal::Scalar,
-    A: Copy,
-    V: vector::ConvertArray<DIM, S, Array = A>,
+    S: Copy + Zero + PartialEq,
+    V: vector::ConvertArray<D, S, Array = [S; D]>,
 {
     #[inline]
     fn store<I>(input: I) -> Self
@@ -322,11 +230,10 @@ where
     }
 }
 
-impl<const DIM: usize, S, V, T> Storage<PointMass<V, S>> for MassiveAffectedInternal<DIM, S, V>
+impl<const D: usize, S, V> Storage<PointMass<V, S>> for MassiveAffectedInternal<D, S, V>
 where
-    S: internal::Scalar,
-    T: internal::Vector<Scalar = S>,
-    V: internal::ConvertInternalVector<DIM, S, Vector = T>,
+    S: Copy + Zero + PartialEq,
+    V: internal::ConvertInternal<D, S>,
 {
     #[inline]
     fn store<I>(input: I) -> Self
@@ -339,34 +246,59 @@ where
     }
 }
 
-impl<const L: usize, T, S, V> Storage<PointMass<V, S::Element>> for MassiveAffectedSIMD<L, T, S>
+impl<const L: usize, const D: usize, S, V> Storage<PointMass<V, S>>
+    for MassiveAffectedSIMD<L, D, S, V>
 where
-    S: simd::Scalar<L>,
-    T: simd::Vector<L, Scalar = S>,
-    V: simd::IntoVectorElement<T::Element, Vector = T>,
-{
-    #[inline]
-    fn store<I>(input: I) -> Self
-    where
-        I: Iterator<Item = PointMass<V, S::Element>>,
-    {
-        Self::from_affected(input.map(PointMass::into_element).collect())
-    }
-}
-
-impl<const N: usize, const DIM: usize, S, V, T> Storage<PointMass<V, S>>
-    for TreeAffectedInternal<N, DIM, S, V>
-where
-    S: internal::Scalar,
-    T: internal::Vector<Scalar = S> + Into<[S; DIM]>,
-    V: internal::ConvertInternalVector<DIM, S, Vector = T>,
-    BoundingBox<[S; DIM]>: SubDivide<Divison = [BoundingBox<[S; DIM]>; N]>,
+    S: Copy + Zero + PartialEq,
+    V: simd::ConvertSIMD<L, D, S>,
 {
     #[inline]
     fn store<I>(input: I) -> Self
     where
         I: Iterator<Item = PointMass<V, S>>,
     {
-        Self::from_affected(input.map(PointMass::into_internal).collect())
+        let affected = input.map(PointMass::into).collect();
+        let MassiveAffected { massive, affected } = MassiveAffected::from_affected(affected);
+
+        let massive = massive
+            .chunks(L)
+            .map(|slice| {
+                let mut body_8 = [PointMass::ZERO; L];
+                body_8[..slice.len()].copy_from_slice(slice);
+                PointMass::new(
+                    simd::SIMD::from_lanes(body_8.map(|p| p.position)),
+                    simd::SIMD::from_lanes(body_8.map(|p| p.mass)),
+                )
+            })
+            .collect();
+
+        Self(MassiveAffected { massive, affected })
+    }
+}
+
+impl<const N: usize, const D: usize, S, V> Storage<PointMass<V, S>>
+    for TreeAffectedInternal<N, D, S, V>
+where
+    S: internal::Scalar,
+    V: internal::ConvertInternal<D, S>,
+    BoundingBox<V::Array>: SubDivide<Divison = [BoundingBox<V::Array>; N]>,
+{
+    #[inline]
+    fn store<I>(input: I) -> Self
+    where
+        I: Iterator<Item = PointMass<V, S>>,
+    {
+        let affected = input.map(PointMass::into_internal).collect();
+        let MassiveAffected { massive, affected } = MassiveAffected::from_affected(affected);
+
+        let mut tree = BarnesHutTree::new();
+        let bbox = BoundingBox::square_with(massive.iter().map(|p| p.position.into()));
+        let root = tree.build_node(&massive, bbox);
+
+        Self {
+            tree,
+            root,
+            affected,
+        }
     }
 }

--- a/particular/src/algorithms/tree/barnes_hut.rs
+++ b/particular/src/algorithms/tree/barnes_hut.rs
@@ -5,15 +5,16 @@ use crate::algorithms::{
 };
 
 /// Trait to compute the acceleration of particles using the [Barnes-Hut](https://en.wikipedia.org/wiki/Barnes%E2%80%93Hut_simulation) algorithm.
-pub trait BarnesHutTree<T, S> {
+pub trait BarnesHutAcceleration<T, S> {
     /// Computes the acceleration at the given position from a node of the tree.
     fn acceleration_at(&self, node: Option<NodeID>, position: T, theta: S) -> T;
 }
 
-type CompatibleTree<T, S, const DIM: usize, const N: usize> =
-    Tree<SizedOrthant<N, BoundingBox<[S; DIM]>>, PointMass<T, S>>;
+/// Trees that can be used with the [`BarnesHutAcceleration`] trait.
+pub type BarnesHutTree<const N: usize, const D: usize, T, S> =
+    Tree<SizedOrthant<N, BoundingBox<[S; D]>>, PointMass<T, S>>;
 
-impl<T, S, const DIM: usize, const N: usize> BarnesHutTree<T, S> for CompatibleTree<T, S, DIM, N>
+impl<T, S, const D: usize, const N: usize> BarnesHutAcceleration<T, S> for BarnesHutTree<N, D, T, S>
 where
     S: internal::Scalar,
     T: internal::Vector<Scalar = S>,

--- a/particular/src/algorithms/tree/bbox.rs
+++ b/particular/src/algorithms/tree/bbox.rs
@@ -12,20 +12,20 @@ pub struct BoundingBox<A> {
 }
 
 #[allow(clippy::needless_range_loop)]
-impl<const DIM: usize, S> BoundingBox<[S; DIM]>
+impl<const D: usize, S> BoundingBox<[S; D]>
 where
     S: internal::Scalar,
 {
     /// Creates a new [`BoundingBox`] with the given min and max values.
     #[inline]
-    pub fn new(min: [S; DIM], max: [S; DIM]) -> Self {
+    pub fn new(min: [S; D], max: [S; D]) -> Self {
         Self { min, max }
     }
 
     /// Extends the [`BoundingBox`] so that it contains the given position.
     #[inline]
-    pub fn extend(&mut self, position: [S; DIM]) {
-        for i in 0..DIM {
+    pub fn extend(&mut self, position: [S; D]) {
+        for i in 0..D {
             self.min[i] = self.min[i].min(position[i]);
             self.max[i] = self.max[i].max(position[i]);
         }
@@ -33,7 +33,7 @@ where
 
     /// Creates a new [`BoundingBox`] that contains the given positions.
     #[inline]
-    pub fn with(positions: impl Iterator<Item = [S; DIM]>) -> Self {
+    pub fn with(positions: impl Iterator<Item = [S; D]>) -> Self {
         let mut result = Self::default();
         for position in positions {
             result.extend(position)
@@ -43,7 +43,7 @@ where
 
     /// Creates a new square [`BoundingBox`] that contains the given positions.
     #[inline]
-    pub fn square_with(positions: impl Iterator<Item = [S; DIM]>) -> Self {
+    pub fn square_with(positions: impl Iterator<Item = [S; D]>) -> Self {
         let mut result = Self::with(positions);
 
         let center = result.center();
@@ -53,7 +53,7 @@ where
             .fold(S::ZERO, S::max)
             .midpoint(S::ZERO);
 
-        for i in 0..DIM {
+        for i in 0..D {
             result.min[i] = center[i] - half_length;
             result.max[i] = center[i] + half_length;
         }
@@ -63,9 +63,9 @@ where
 
     /// Returns the center of the [`BoundingBox`].
     #[inline]
-    pub fn center(&self) -> [S; DIM] {
-        let mut r = [S::ZERO; DIM];
-        for i in 0..DIM {
+    pub fn center(&self) -> [S; D] {
+        let mut r = [S::ZERO; D];
+        for i in 0..D {
             r[i] = self.min[i].midpoint(self.max[i])
         }
         r
@@ -73,9 +73,9 @@ where
 
     /// Returns the size of the [`BoundingBox`].
     #[inline]
-    pub fn size(&self) -> [S; DIM] {
-        let mut r = [S::ZERO; DIM];
-        for i in 0..DIM {
+    pub fn size(&self) -> [S; D] {
+        let mut r = [S::ZERO; D];
+        for i in 0..D {
             r[i] = self.max[i] - self.min[i]
         }
         r
@@ -88,15 +88,15 @@ where
     }
 }
 
-impl<const DIM: usize, S> Default for BoundingBox<[S; DIM]>
+impl<const D: usize, S> Default for BoundingBox<[S; D]>
 where
     S: internal::Scalar,
 {
     #[inline]
     fn default() -> Self {
         Self {
-            min: [S::INFINITY; DIM],
-            max: [-S::INFINITY; DIM],
+            min: [S::INFINITY; D],
+            max: [-S::INFINITY; D],
         }
     }
 }
@@ -110,7 +110,7 @@ pub trait SubDivide {
     type Divison: Default + Index<usize, Output = Self> + IndexMut<usize, Output = Self>;
 }
 
-impl<const DIM: usize, S> BoundingBox<[S; DIM]>
+impl<const D: usize, S> BoundingBox<[S; D]>
 where
     Self: SubDivide,
     S: internal::Scalar,
@@ -124,10 +124,10 @@ where
 
         let mut result = <Self as SubDivide>::Divison::default();
         for i in 0..Self::N {
-            let mut corner_min = [S::ZERO; DIM];
-            let mut corner_max = [S::ZERO; DIM];
+            let mut corner_min = [S::ZERO; D];
+            let mut corner_max = [S::ZERO; D];
 
-            for j in 0..DIM {
+            for j in 0..D {
                 if (i & (1 << j)) == 0 {
                     corner_min[j] = bbox_center[j];
                     corner_max[j] = bbox_max[j];

--- a/particular/src/algorithms/vector.rs
+++ b/particular/src/algorithms/vector.rs
@@ -4,17 +4,24 @@ pub trait Zero {
     const ZERO: Self;
 }
 
+impl<const D: usize, S> Zero for [S; D]
+where
+    S: Zero,
+{
+    const ZERO: Self = [S::ZERO; D];
+}
+
 /// Marker trait for arbitrary vectors that can be converted from and into an array.
-pub trait ConvertArray<const DIM: usize, S>: From<Self::Array> + Into<Self::Array> {
+pub trait ConvertArray<const D: usize, S>: From<Self::Array> + Into<Self::Array> {
     /// Internal representation of a vector.
     type Array;
 }
 
-impl<const DIM: usize, S, V> ConvertArray<DIM, S> for V
+impl<const D: usize, S, V> ConvertArray<D, S> for V
 where
-    V: From<[S; DIM]> + Into<[S; DIM]>,
+    V: From<[S; D]> + Into<[S; D]>,
 {
-    type Array = [S; DIM];
+    type Array = [S; D];
 }
 
 /// Internal representation of vectors used for expensive computations.
@@ -27,9 +34,9 @@ pub mod internal {
     };
 
     /// Trait for arbitrary vectors that can be converted from and into a specified [`Vector`].
-    pub trait ConvertInternalVector<const DIM: usize, S>: ConvertArray<DIM, S> {
+    pub trait ConvertInternal<const D: usize, S>: ConvertArray<D, S, Array = [S; D]> {
         /// Internal representation of a vector.
-        type Vector: From<Self::Array> + Into<Self::Array>;
+        type Vector: From<Self::Array> + Into<Self::Array> + Vector<Scalar = S>;
 
         /// Converts the arbitrary vector into its internal representation.
         #[inline]
@@ -95,8 +102,6 @@ pub mod internal {
         + SubAssign
         + MulAssign
         + DivAssign
-        + From<Self::Array>
-        + Into<Self::Array>
         + Add<Output = Self>
         + Sub<Output = Self>
         + Mul<Self::Scalar, Output = Self>
@@ -104,9 +109,6 @@ pub mod internal {
     {
         /// The scalar type of the vector.
         type Scalar: Scalar;
-
-        /// Array type this vector can be converted from and to.
-        type Array;
 
         /// Norm squared, defined by the dot product on itself.
         fn length_squared(self) -> Self::Scalar;
@@ -145,8 +147,6 @@ pub mod internal {
             impl Vector for $t {
                 type Scalar = $s;
 
-                type Array = [$s; $dim];
-
                 #[inline]
                 fn length_squared(self) -> $s {
                     self.length_squared()
@@ -157,7 +157,7 @@ pub mod internal {
                 const ZERO: Self = <$t>::ZERO;
             }
 
-            impl<V> ConvertInternalVector<$dim, $s> for V
+            impl<V> ConvertInternal<$dim, $s> for V
             where
                 V: Into<[$s; $dim]> + From<[$s; $dim]>,
             {
@@ -171,51 +171,40 @@ pub mod internal {
     internal_vector!(f64, (glam::DVec2, 2), (glam::DVec3, 3), (glam::DVec4, 4));
 }
 
-// /// [`InternalVector`](internal::IntoVectorArray::Vector) of an arbitrary vector.
-// pub type InternalVector<V, A> = <V as internal::IntoVectorArray<A>>::Vector;
-
-// /// [`InternalScalar`](internal::Vector::Scalar) of the [`InternalVector`](internal::IntoVectorArray::Vector) of an arbitrary vector.
-// pub type InternalScalar<V, A> = <InternalVector<V, A> as internal::Vector>::Scalar;
-
 /// SIMD representation of vectors used for expensive computations.
 pub mod simd {
-    use super::Zero;
+    use super::{ConvertArray, Zero};
     use std::{
         fmt::Debug,
         ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     };
 
-    /// Arbitrary vectors that can be converted into the [`SIMD::Element`] of a given [`Vector`].
-    pub trait IntoVectorElement<E> {
-        /// SIMD representation of a vector.
-        type Vector;
+    /// Marker trait for arbitrary vectors and the types used for its SIMD representation.
+    pub trait ConvertSIMD<const L: usize, const D: usize, S>:
+        ConvertArray<D, S, Array = [S; D]>
+    {
+        /// SIMD representation of the [`ConvertSIMD::Vector`]'s scalar.
+        type Scalar: Scalar<L, Element = S>;
 
-        /// Converts the arbitrary vector into its [`SIMD::Element`].
-        fn into_element(self) -> E;
-
-        /// Creates a new arbitrary vector from its reduced SIMD representation.
-        fn from_reduced(reduced: <Self::Vector as ReduceAdd>::Output) -> Self
-        where
-            Self::Vector: ReduceAdd;
+        /// SIMD representation of the vector.
+        type Vector: Vector<L, Element = Self::Array, Scalar = Self::Scalar>
+            + ReduceAdd<Output = Self::Array>;
     }
 
     /// Trait for SIMD objects and their creation.
-    pub trait SIMD<const LANES: usize> {
+    pub trait SIMD<const L: usize> {
         /// Element from which the SIMD value can be created.
-        type Element: Element;
+        type Element;
 
         /// Creates a SIMD value with all lanes set to the specified value.
         fn splat(value: Self::Element) -> Self;
 
         /// Creates a SIMD value with lanes set to the given values.
-        fn from_lanes(values: [Self::Element; LANES]) -> Self;
+        fn from_lanes(values: [Self::Element; L]) -> Self;
     }
 
-    /// Elements of [`SIMD`] objects.
-    pub trait Element: Send + Sync + Copy + Zero + Default + PartialEq {}
-
     /// Scalar types that compose [`Vector`] objects.
-    pub trait Scalar<const LANES: usize>:
+    pub trait Scalar<const L: usize>:
         Send
         + Sync
         + Copy
@@ -227,7 +216,7 @@ pub mod simd {
         + MulAssign
         + DivAssign
         + PartialEq
-        + SIMD<LANES>
+        + SIMD<L>
         + Add<Output = Self>
         + Sub<Output = Self>
         + Mul<Output = Self>
@@ -245,7 +234,7 @@ pub mod simd {
     }
 
     /// SIMD vectors used for expensive computations.
-    pub trait Vector<const LANES: usize>:
+    pub trait Vector<const L: usize>:
         Send
         + Sync
         + Copy
@@ -257,14 +246,14 @@ pub mod simd {
         + MulAssign
         + DivAssign
         + ReduceAdd
-        + SIMD<LANES>
+        + SIMD<L>
         + Add<Output = Self>
         + Sub<Output = Self>
         + Mul<Self::Scalar, Output = Self>
         + Div<Self::Scalar, Output = Self>
     {
         /// The scalar type of the vector.
-        type Scalar;
+        type Scalar: Scalar<L>;
 
         /// Norm squared, defined by the dot product on itself.
         fn length_squared(self) -> Self::Scalar;
@@ -286,9 +275,7 @@ pub mod simd {
     }
 
     macro_rules! simd_vector {
-        ($l: literal, $s: ty => $se: ty, $(($t: ty => $te: ty, $dim: literal)),*) => {
-            impl Element for $se {}
-
+        ($l: literal, ($s: ty, $se: ty), $(($t: ty, $te: ty, $dim: literal)),*) => {
             impl SIMD<$l> for $s {
                 type Element = $se;
 
@@ -307,23 +294,17 @@ pub mod simd {
                 const ZERO: Self = <$s>::ZERO;
             }
         $(
-            impl Element for $te {}
-
-            impl Zero for $te {
-                const ZERO: Self = Self::broadcast(<$se>::ZERO);
-            }
-
             impl SIMD<$l> for $t {
-                type Element = $te;
+                type Element = [$se; $dim];
 
                 #[inline]
                 fn splat(value: Self::Element) -> Self {
-                    Self::splat(value)
+                    Self::splat(value.into())
                 }
 
                 #[inline]
                 fn from_lanes(values: [Self::Element; $l]) -> Self {
-                    Self::from(values)
+                    Self::from(values.map(<$te>::from))
                 }
             }
 
@@ -350,21 +331,13 @@ pub mod simd {
                 const ZERO: Self = Self::broadcast(<$s>::ZERO);
             }
 
-            impl<V> IntoVectorElement<$te> for V
+            impl<V> ConvertSIMD<$l, $dim, $se> for V
             where
-                V: Into<[$se; $dim]> + From<[$se; $dim]>,
+                V: From<[$se; $dim]> + Into<[$se; $dim]>,
             {
+                type Scalar = $s;
+
                 type Vector = $t;
-
-                #[inline]
-                fn into_element(self) -> $te {
-                    <$te>::from(self.into())
-                }
-
-                #[inline]
-                fn from_reduced(reduced: [$se; $dim]) -> Self {
-                    V::from(reduced)
-                }
             }
         )*
         };
@@ -433,18 +406,18 @@ pub mod simd {
 
     simd_vector!(
         8,
-        ultraviolet::f32x8 => f32,
-        (ultraviolet::Vec2x8 => ultraviolet::Vec2, 2),
-        (ultraviolet::Vec3x8 => ultraviolet::Vec3, 3),
-        (ultraviolet::Vec4x8 => ultraviolet::Vec4, 4)
+        (ultraviolet::f32x8, f32),
+        (ultraviolet::Vec2x8, ultraviolet::Vec2, 2),
+        (ultraviolet::Vec3x8, ultraviolet::Vec3, 3),
+        (ultraviolet::Vec4x8, ultraviolet::Vec4, 4)
     );
 
     simd_vector!(
         4,
-        ultraviolet::f64x4 => f64,
-        (ultraviolet::DVec2x4 => ultraviolet::DVec2, 2),
-        (ultraviolet::DVec3x4 => ultraviolet::DVec3, 3),
-        (ultraviolet::DVec4x4 => ultraviolet::DVec4, 4)
+        (ultraviolet::f64x4, f64),
+        (ultraviolet::DVec2x4, ultraviolet::DVec2, 2),
+        (ultraviolet::DVec3x4, ultraviolet::DVec3, 3),
+        (ultraviolet::DVec4x4, ultraviolet::DVec4, 4)
     );
 
     impl_reduce_add_vec2!((ultraviolet::Vec2x8, f32), (ultraviolet::DVec2x4, f64));
@@ -453,12 +426,3 @@ pub mod simd {
 
     impl_reduce_add_vec4!((ultraviolet::Vec4x8, f32), (ultraviolet::DVec4x4, f64));
 }
-
-/// [`Element`](simd::SIMD::Element) of a SIMD type with L lanes.
-pub type SIMDElement<S, const L: usize> = <S as simd::SIMD<L>>::Element;
-
-/// [`SIMDVector`](simd::IntoVectorElement::Vector) of an arbitrary vector.
-pub type SIMDVector<V, E> = <V as simd::IntoVectorElement<E>>::Vector;
-
-/// [`SIMDScalar`](simd::Vector::Scalar) of the [`SIMDVector`](simd::IntoVectorElement::Vector) of an arbitrary vector.
-pub type SIMDScalar<V, E, const L: usize> = <SIMDVector<V, E> as simd::Vector<L>>::Scalar;


### PR DESCRIPTION
- Apart from simplifying the code in most places, this allows to keep the type information of the arbitrary vector on the storage used in a `ComputeMethod`. Type information is no longer needed for the output vector using the built-in storages when calling `compute` on available compute methods.
- Making `ComputeMethod` implementations generic is a little easier using `ConvertX` traits for both simd and internal vector abstractions, though they require a `const D: usize` generic.